### PR TITLE
Fix Flutter 3 build

### DIFF
--- a/lib/screens/loginscreen.dart
+++ b/lib/screens/loginscreen.dart
@@ -79,9 +79,9 @@ class Login extends StatelessWidget {
                               Navigator.pushReplacementNamed(context, "/");
                             },
                             style: ElevatedButton.styleFrom(
-                                primary: const Color(0xff5956E9),
-                                fixedSize: Size(314.0, 70.0),
-                                onPrimary: Colors.white,
+                                backgroundColor: const Color(0xff5956E9),
+                                fixedSize: const Size(314.0, 70.0),
+                                foregroundColor: Colors.white,
                                 shape: RoundedRectangleBorder(
                                     borderRadius: BorderRadius.circular(10.0)),
                                 padding:

--- a/lib/screens/profile.dart
+++ b/lib/screens/profile.dart
@@ -46,7 +46,7 @@ class Profile extends StatelessWidget {
                     children: <Widget>[
                       const SizedBox(height: 12),
                       Stack(
-                        overflow: Overflow.visible,
+                        clipBehavior: Clip.none,
                         alignment: AlignmentDirectional.topCenter,
                         fit: StackFit.loose,
                         children: <Widget>[

--- a/lib/screens/singleitemscreen.dart
+++ b/lib/screens/singleitemscreen.dart
@@ -3,14 +3,14 @@ import 'package:ecommerce_app/widgets/buttonmini.dart';
 import 'package:ecommerce_app/widgets/carditem.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
-import 'package:carousel_slider/carousel_slider.dart';
+import 'package:carousel_slider/carousel_slider.dart' as carousel;
 
 class SingleItem extends StatelessWidget {
   const SingleItem({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    CarouselController buttonCarouselController = CarouselController();
+    carousel.CarouselController buttonCarouselController = carousel.CarouselController();
     return Scaffold(
         backgroundColor: const Color(0xffF6F6F9),
         body: Column(
@@ -110,7 +110,7 @@ class SingleItem extends StatelessWidget {
                         alignment: Alignment.topLeft,
                         padding: const EdgeInsets.only(left:45),
                         child: ElevatedButton(
-                            style: ElevatedButton.styleFrom(primary: Colors.white,padding: EdgeInsets.all(0.0),elevation: 0.0),
+                            style: ElevatedButton.styleFrom(backgroundColor: Colors.white,padding: EdgeInsets.all(0.0),elevation: 0.0),
                             onPressed: (){}, child: const Text('Full description ->',
                           style: TextStyle(color: Color(0xff5956E9),fontSize: 15,fontWeight: FontWeight.w700,fontFamily: 'Raleway'),)
                         )
@@ -152,14 +152,14 @@ class CarouselWithIndicatorDemo extends StatefulWidget {
 
 class _CarouselWithIndicatorState extends State<CarouselWithIndicatorDemo> {
   int _current = 0;
-  final CarouselController _controller = CarouselController();
+  final carousel.CarouselController _controller = carousel.CarouselController();
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       body: Column(children: <Widget>[
         Expanded(
-          child: CarouselSlider(
+          child: carousel.CarouselSlider(
             items: const [
               Image(
                 image: AssetImage('assets/images/ipad.png'),
@@ -172,7 +172,7 @@ class _CarouselWithIndicatorState extends State<CarouselWithIndicatorDemo> {
               )
             ],
             carouselController: _controller,
-            options: CarouselOptions(
+            options: carousel.CarouselOptions(
                 height: 240,
                 autoPlay: true,
                 enlargeCenterPage: true,

--- a/lib/screens/splashscreen.dart
+++ b/lib/screens/splashscreen.dart
@@ -40,8 +40,8 @@ class Splash extends StatelessWidget {
                         fit: BoxFit.contain))),
             ElevatedButton(
               style: ElevatedButton.styleFrom(
-                primary: Colors.white,
-                onPrimary: const Color(0xff5956E9),
+                backgroundColor: Colors.white,
+                foregroundColor: const Color(0xff5956E9),
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(10.0),
                 ),

--- a/lib/widgets/button.dart
+++ b/lib/widgets/button.dart
@@ -22,7 +22,7 @@ class Button extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ButtonStyle style = ElevatedButton.styleFrom(
-      primary: color,
+      backgroundColor: color,
       textStyle: TextStyle(fontSize: fontSize, fontWeight: FontWeight.bold),
     );
     return ConstrainedBox(

--- a/lib/widgets/buttonmini.dart
+++ b/lib/widgets/buttonmini.dart
@@ -10,7 +10,7 @@ class ButtonMini extends StatelessWidget {
     return Container(
 
       child:  ElevatedButton(
-          style: ElevatedButton.styleFrom(shadowColor: Colors.black,elevation: 4.0,primary: Colors.white,onPrimary: Colors.black),
+          style: ElevatedButton.styleFrom(shadowColor: Colors.black,elevation: 4.0,backgroundColor: Colors.white,foregroundColor: Colors.black),
           onPressed: (){},
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceEvenly,

--- a/lib/widgets/caroussel.dart
+++ b/lib/widgets/caroussel.dart
@@ -1,20 +1,20 @@
 import 'package:ecommerce_app/widgets/carditem.dart';
 import 'package:flutter/material.dart';
-import 'package:carousel_slider/carousel_slider.dart';
+import 'package:carousel_slider/carousel_slider.dart' as carousel;
 
 class Caroussel extends StatelessWidget {
   const Caroussel({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    CarouselController buttonCarouselController = CarouselController();
+    carousel.CarouselController buttonCarouselController = carousel.CarouselController();
 
     return Column(
       children: <Widget>[
-        CarouselSlider(
+        carousel.CarouselSlider(
           carouselController: buttonCarouselController,
           items: [CardItem(), CardItem(), CardItem()],
-          options: CarouselOptions(
+          options: carousel.CarouselOptions(
             height: 308,
             autoPlay: false,
             enlargeCenterPage: true,

--- a/lib/widgets/cart_item.dart
+++ b/lib/widgets/cart_item.dart
@@ -20,7 +20,7 @@ class CartItem extends StatelessWidget {
       minimumSize: const Size(22, 22),
       maximumSize: const Size(22, 22),
       elevation: 0,
-      primary: Color(0xFF7DCCEC),
+      backgroundColor: const Color(0xFF7DCCEC),
     );
 
     return Container(


### PR DESCRIPTION
## Summary
- update ElevatedButton style parameters for Flutter 3.x
- remove deprecated `overflow` on `Stack`
- alias carousel_slider imports to avoid name clash

## Testing
- `apt-get update`
- `apt-get install -y flutter` *(fails: Unable to locate package)*
- `apt-get install -y dart` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6886a80f91a4832197a4b40e1dd1aa93